### PR TITLE
adding configurable target bitrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The Opus encoder will not work if the value is not 8000, 12000, 16000, 24000 or 
 - **maxBuffersPerPage** - (*optional*) Specifies the maximum number of buffers to use before generating an Ogg page. This can be used to lower the streaming latency. The lower the value the more overhead the ogg stream will incur. Defaults to 40.
 - **encoderApplication** - (*optional*) Specifies the encoder application. Supported values are 2048 - Voice, 2049 - Full Band Audio, 2051 - Restricted Low Delay. Defaults to 2049.
 - **encoderFrameSize** (*optional*) Specifies the frame size in ms used for encoding. Defaults to 20.
+- **bitRate** (*optional*) Specifies the target bitrate in bits/sec. The encoder selects an application-specific default when this is not specified.
 
 
 ---------

--- a/example.html
+++ b/example.html
@@ -49,6 +49,11 @@
     <input id="sampleRate" type="number" value="48000" />
   </div>
 
+  <div>
+    <label>bitRate</label>
+    <input id="bitRate" type="number" value="72000" />
+  </div>
+
   <h2>Commands</h2>
   <button id="init">init</button>
   <button id="start" disabled>start</button>
@@ -80,7 +85,8 @@
         numberOfChannels: numberOfChannels.value,
         bitDepth: bitDepth.options[ bitDepth.selectedIndex ].value,
         recordOpus: recordOpus.checked,
-        sampleRate: sampleRate.value
+        sampleRate: sampleRate.value,
+        bitRate: bitRate.value
       });
 
       recorder.addEventListener( "start", function(e){

--- a/example.html
+++ b/example.html
@@ -51,7 +51,7 @@
 
   <div>
     <label>bitRate</label>
-    <input id="bitRate" type="number" value="72000" />
+    <input id="bitRate" type="number" value="64000" />
   </div>
 
   <h2>Commands</h2>

--- a/example.html
+++ b/example.html
@@ -81,9 +81,8 @@
         monitorGain: monitorGain.value,
         numberOfChannels: numberOfChannels.value,
         bitDepth: bitDepth.options[ bitDepth.selectedIndex ].value,
-        recordOpus: recordOpus.checked,
-        sampleRate: sampleRate.value,
-        bitRate: bitRate.value
+        recordOpus: recordOpus.checked ? {bitRate: bitRate.value} : false,
+        sampleRate: sampleRate.value
       });
 
       recorder.addEventListener( "start", function(e){

--- a/oggopus.js
+++ b/oggopus.js
@@ -8,6 +8,7 @@ var OggOpus = function( config ){
   this.maxBuffersPerPage = config.recordOpus.maxBuffersPerPage || 40; // Limit latency for streaming
   this.encoderApplication = config.recordOpus.encoderApplication || 2049; // 2048 = Voice, 2049 = Full Band Audio, 2051 = Restricted Low Delay
   this.encoderFrameSize = config.recordOpus.encoderFrameSize || 20; // 20ms frame
+  this.bitRate = config.bitRate;
   this.wavepcm = new WavePCM( config );
 
   this.pageIndex = 0;
@@ -139,6 +140,32 @@ OggOpus.prototype.initChecksumTable = function(){
 
 OggOpus.prototype.initCodec = function() {
   this.encoder = _opus_encoder_create( this.outputSampleRate, this.numberOfChannels, this.encoderApplication, allocate(4, 'i32', ALLOC_STACK) );
+
+  var bitrateLocation = _malloc(4);
+  HEAP32[bitrateLocation >>> 2] = this.bitRate;
+  _opus_encoder_ctl(
+    this.encoder,
+    4002, // OPUS_SET_BITRATE_REQUEST
+    bitrateLocation)
+  ;
+  _free(bitrateLocation);
+
+
+  var resultLocation = _malloc(4);
+  var resultLocationLocation = _malloc(4);
+  HEAP32[resultLocationLocation >>> 2] = resultLocation;
+
+  _opus_encoder_ctl(
+    this.encoder,
+    4003, // OPUS_GET_BITRATE_REQUEST
+    resultLocationLocation
+  );
+
+  var result = HEAPU32[resultLocation >>> 2];
+  _free(resultLocationLocation);
+  _free(resultLocation);
+  console.log("OPUS_GET_BITRATE=" + result);
+
   this.encoderBufferIndex = 0;
   this.encoderSamplesPerChannelPerPacket = this.outputSampleRate * this.encoderFrameSize / 1000;
   this.encoderBufferLength = this.encoderSamplesPerChannelPerPacket * this.numberOfChannels;

--- a/oggopus.js
+++ b/oggopus.js
@@ -140,30 +140,12 @@ OggOpus.prototype.initChecksumTable = function(){
 OggOpus.prototype.initCodec = function() {
   this.encoder = _opus_encoder_create( this.outputSampleRate, this.numberOfChannels, this.encoderApplication, allocate(4, 'i32', ALLOC_STACK) );
 
-  var bitrateLocation = _malloc(4);
-  HEAP32[bitrateLocation >>> 2] = this.bitRate;
-  _opus_encoder_ctl(
-    this.encoder,
-    4002, // OPUS_SET_BITRATE_REQUEST
-    bitrateLocation)
-  ;
-  _free(bitrateLocation);
-
-
-  var resultLocation = _malloc(4);
-  var resultLocationLocation = _malloc(4);
-  HEAP32[resultLocationLocation >>> 2] = resultLocation;
-
-  _opus_encoder_ctl(
-    this.encoder,
-    4003, // OPUS_GET_BITRATE_REQUEST
-    resultLocationLocation
-  );
-
-  var result = HEAPU32[resultLocation >>> 2];
-  _free(resultLocationLocation);
-  _free(resultLocation);
-  console.log("OPUS_GET_BITRATE=" + result);
+  if ( this.bitRate ) {
+    var bitrateLocation = _malloc( 4 );
+    HEAP32[bitrateLocation >>> 2] = this.bitRate;
+    _opus_encoder_ctl( this.encoder, 4002, bitrateLocation );
+    _free( bitrateLocation );
+  }
 
   this.encoderBufferIndex = 0;
   this.encoderSamplesPerChannelPerPacket = this.outputSampleRate * this.encoderFrameSize / 1000;

--- a/oggopus.js
+++ b/oggopus.js
@@ -8,7 +8,7 @@ var OggOpus = function( config ){
   this.maxBuffersPerPage = config.recordOpus.maxBuffersPerPage || 40; // Limit latency for streaming
   this.encoderApplication = config.recordOpus.encoderApplication || 2049; // 2048 = Voice, 2049 = Full Band Audio, 2051 = Restricted Low Delay
   this.encoderFrameSize = config.recordOpus.encoderFrameSize || 20; // 20ms frame
-  this.bitRate = config.bitRate;
+  this.bitRate = config.recordOpus.bitRate;
   this.wavepcm = new WavePCM( config );
 
   this.pageIndex = 0;
@@ -141,10 +141,10 @@ OggOpus.prototype.initCodec = function() {
   this.encoder = _opus_encoder_create( this.outputSampleRate, this.numberOfChannels, this.encoderApplication, allocate(4, 'i32', ALLOC_STACK) );
 
   if ( this.bitRate ) {
-    var bitrateLocation = _malloc( 4 );
-    HEAP32[bitrateLocation >>> 2] = this.bitRate;
-    _opus_encoder_ctl( this.encoder, 4002, bitrateLocation );
-    _free( bitrateLocation );
+    var bitRateLocation = _malloc( 4 );
+    HEAP32[bitRateLocation >>> 2] = this.bitRate;
+    _opus_encoder_ctl( this.encoder, 4002, bitRateLocation );
+    _free( bitRateLocation );
   }
 
   this.encoderBufferIndex = 0;

--- a/recorder.js
+++ b/recorder.js
@@ -147,7 +147,8 @@ Recorder.prototype.start = function(){
       inputSampleRate: this.audioContext.sampleRate,
       numberOfChannels: this.config.numberOfChannels,
       outputSampleRate: this.config.sampleRate,
-      recordOpus: this.config.recordOpus
+      recordOpus: this.config.recordOpus,
+      bitRate: this.config.bitRate
     });
 
     this.state = "recording";

--- a/recorder.js
+++ b/recorder.js
@@ -148,8 +148,7 @@ Recorder.prototype.start = function(){
       inputSampleRate: this.audioContext.sampleRate,
       numberOfChannels: this.config.numberOfChannels,
       outputSampleRate: this.config.sampleRate,
-      recordOpus: this.config.recordOpus,
-      bitRate: this.config.bitRate
+      recordOpus: this.config.recordOpus
     });
 
     this.state = "recording";


### PR DESCRIPTION
I've tried to stick close to the coding style used throughout the project. 

Rather than fall back on a default target bitrate in ```recorder.js```, if ```new Recorder``` is initialized without a bitrate key in the configuration object, the bitrate simply isn't set (which means the encoder goes with its default). I figured this was the best course of action, given that the encoder has different default bitrates depending on the selected encoder application.