### PR TITLE
Fix #22 - page load errors in unsupported browsers

### DIFF
--- a/recorder.js
+++ b/recorder.js
@@ -1,5 +1,5 @@
 "use strict";
-AudioContext = AudioContext || webkitAudioContext || mozAudioContext;
+window.AudioContext = window.AudioContext || window.webkitAudioContext || window.mozAudioContext;
 navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
 
 var Recorder = function( config ){


### PR DESCRIPTION
In unsupported browsers (like latest Safari) the way this was previously written would cause the page to error out due to AudioContext not being defined.

By scoping to the window object we avoid the reference error and the page will no longer error.