### PR TITLE
Fix encoding example

### DIFF
--- a/example/encoder.html
+++ b/example/encoder.html
@@ -70,7 +70,8 @@
         numberOfChannels: parseInt(numberOfChannels.value, 10),
         bitRate: parseInt(bitRate.value,10),
         encoderSampleRate: parseInt(encoderSampleRate.value,10),
-        encoderPath: "../build/encoderWorker.min.js"
+        encoderPath: "../build/encoderWorker.min.js",
+        streamPages: true
       });
 
       recorder.addEventListener( "start", function(e){


### PR DESCRIPTION
First off thanks for this awesome project! It is incredibly helpful

The "dataAvaliable" listener isn't triggered in the encoding example because the config lacks `streamPages: true`. This results in there recordings not being shown:
<img width="406" alt="screen shot 2016-09-16 at 15 00 45" src="https://cloud.githubusercontent.com/assets/2257156/18602485/61bd1bf2-7c1e-11e6-88ef-443cc6b602bd.png">

To replicate, click "init" then "start". The recording elements wont appear on the current example:
Current Version: https://rawgit.com/chris-rudmin/Recorderjs/master/example/encoder.html
but will appear on my branch:
PR Version: https://rawgit.com/colinwren/Recorderjs/master/example/encoder.html