### PR TITLE
Add warning for using raw source files on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ Make the dependencies using command `make`!
 ---------
 ### Required Files
 
-The required files to record audio to ogg/opus are `build/recorder.min.js` and `build/encoderWorker.min.js`. Optionally `build/decoderWorker.min.js` will help decode ogg/opus files and `build/waveWorker.min.js` is a helper to transform floating point PCM data into wave/pcm.
+The required files to record audio to ogg/opus are `build/recorder.min.js` and `build/encoderWorker.min.js`. Optionally `build/decoderWorker.min.js` will help decode ogg/opus files and `build/waveWorker.min.js` is a helper to transform floating point PCM data into wave/pcm. The source files in `src/` folder do not work without building process; it produces  `ReferenceError: _malloc is not defined`). You need to either use compiled file in `build/` folder or build by yourself.


### PR DESCRIPTION
Regarding the issue #54, I slightly updated documentation in a way that there is less confusion.

Lots of users generally add the source file of libraries, and run. To keep them from wasting time of running raw source code, I added few sentences not to do it.

Thanks for this great library, you saved my tons of time for having compressed audio recording.