### PR TITLE
Change includes method with indexOf to support Microsoft Edge

### DIFF
--- a/src/waveWorker.js
+++ b/src/waveWorker.js
@@ -36,7 +36,7 @@ var WavePCM = function( config ){
     throw new Error("wavSampleRate value is required to record. NOTE: Audio is not resampled!");
   }
 
-  if ( ![8, 16, 24, 32].includes( config['wavBitDepth'] ) ) {
+  if ( [8, 16, 24, 32].indexOf( config['wavBitDepth'] ) < 1 ) {
     throw new Error("Only 8, 16, 24 and 32 bits per sample are supported");
   }
 


### PR DESCRIPTION
I've stumbled upon issue with Microsoft Edge.
Microsoft Edge doesn't support `includes` method but it supports `indexOf` which can be used as a substitution.
Fix is pretty simple as you can see in the commit below.