### PR TITLE
Fix Chrome seeking issues with files produced by opus-recorder

### DIFF
--- a/src/encoderWorker.js
+++ b/src/encoderWorker.js
@@ -324,6 +324,8 @@ if (typeof registerProcessor === 'function') {
             case 'getHeaderPages':
               this.postPage(this.encoder.generateIdPage());
               this.postPage(this.encoder.generateCommentPage());
+              // Match the pre-skip. See chris-rudmin/opus-recorder#248
+              this.granulePosition = 3840;
               break;
 
             case 'done':


### PR DESCRIPTION
I recently discovered that Chrome has some issues with files created using this library. There are a few symptoms, including "ended" events being dispatched early and incorrect (and unstable) durations.

[This codepen][1] contains a simple demonstration of the issue.

I also opened [this bug][2] on the Chromium project.

I'm not _super_ familiar with ogg/opus, but I believe this is a Chrome bug and not technically an issue with opus-recorder, however, the issue isn't reproducible with opus files I've created using other means (encoders on Android and iOS). So, even if the files are technically valid, there must be something that opus-recorder could do differently to avoid the Chrome issue. 🤔

Something that jumped out to me about the files Chrome liked is that they all had a start_pts/start_time (as reported by `ffprobe`) that matched the file's pre-skip, while affected files had a start_pts/start_time of 0. To try to confirm this was related, I modified an affected file so that its start_pts matched its pre-skip:

```
ffmpeg -i bad.ogg -acodec copy -copyts -muxdelay 0 -muxpreload 0 -output_ts_offset 0.08 copy.ogg
```

The result no longer exhibited the problem in Chrome! 🎉

I ran the command again on the copy with an output_ts_offset of 0, just to verify that the issue came back (and therefore it wasn't being fixed by some other random thing the command was doing).

To translate this change to the library, I set the initial granule position to the offset (pre-skip) when encoding. I think this tracks with [the spec's section on PCM sample position][3]:

> The PCM sample position is determined from the granule position using the following formula:
> 
> 'PCM sample position' = 'granule position' - 'pre-skip'

Interestingly, when I tried to set both the initial granule position and pre-skip to a value besides 3840, the issue returned! (It didn't repro on files created on other platforms that had matching, but different, start_pts and pre-skip values.) I'm not sure why this is; maybe the value is hardcoded into the compiled libopus?

Like I said, I'm not opus expert, so I'd love to hear your thoughts on this. Thanks!

[1]: https://codepen.io/matthewwithanm/pen/abWGdbp
[2]: https://bugs.chromium.org/p/chromium/issues/detail?id=1234916
[3]: https://datatracker.ietf.org/doc/html/rfc7845#section-4.3